### PR TITLE
docs: note Cloudflare/pnpm deploy constraint in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,11 @@ reason.
 - **Accessibility:** all `<img>` / `R2Image` need descriptive alt text
   (target WCAG AA).
 - **Deployment:** static build to Cloudflare Workers via `wrangler`.
+- **Cloudflare deploy:** this is a single-package repo deployed on
+  Cloudflare Workers with pnpm 10.x. Do not add `pnpm-workspace.yaml`
+  unless converting to a real workspace with a valid `packages:` field.
+  Handle local pnpm build-approval issues per-machine with
+  `pnpm approve-builds`, not with committed workspace config.
 
 ## Verification requirements
 `pnpm build` must pass before declaring done (it runs `astro check` first,


### PR DESCRIPTION
Adds a deploy constraint to `AGENTS.md` (Architecture constraints) so all AI agents avoid the `pnpm-workspace.yaml` failure mode that broke bobeliadesign.com's Cloudflare build:

> Single-package repo on Cloudflare Workers (pnpm 10.x). Do not add `pnpm-workspace.yaml` without a valid `packages:` field. Handle local pnpm build-approval per-machine (`pnpm approve-builds`), not via committed workspace config.

Preventative/docs-only — this repo isn't broken; the note keeps it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)